### PR TITLE
fixed typo in CB get coordination method

### DIFF
--- a/pconpy/pconpy.py
+++ b/pconpy/pconpy.py
@@ -235,9 +235,9 @@ def get_atom_coord(res, atom_name, verbose=False):
         CA_N = N - CA
         CA_C = C - CA
 
-        rot_mat = Bio.PDB.rotaxis(numpy.pi * 120.0 / 180.0, CA_C)
+        rot_mat = Bio.PDB.rotaxis(-numpy.pi * 120.0 / 180.0, CA_C)
 
-        coord = (CA + N.left_multiply(rot_mat)).get_array()
+        coord = (CA + CA_N.left_multiply(rot_mat)).get_array()
 
     return coord
 


### PR DESCRIPTION
code was not exactly as described in:
http://biopython.org/wiki/The_Biopython_Structural_Bioinformatics_FAQ#How_do_I_put_a_virtual_C.CE.B2_on_a_Gly_residue.3F
which caused GLY to look weird on contact maps